### PR TITLE
Add image metadata handling

### DIFF
--- a/claat/parser/md/README.md
+++ b/claat/parser/md/README.md
@@ -29,6 +29,7 @@ will be understood by the renderer:
   codelab.
 - Analytics Account: A Google Analytics ID to include with all codelab pages.
 - Difficulty: An integer measuring the difficulty of this codelab.
+- Image: An image link to act as a featured image for the codelab.
 
 ## Title
 
@@ -101,4 +102,3 @@ will apply special button-esque styling to any link that begins with the word
 ```
   [Download SDK](https://www.google.com)
 ```
-

--- a/claat/parser/md/parse.go
+++ b/claat/parser/md/parse.go
@@ -50,6 +50,7 @@ const (
 	metaTags             = "tags"
 	metaDifficulty       = "difficulty"
 	metaPublished        = "published"
+	metaImage            = "image"
 )
 
 const (
@@ -403,6 +404,10 @@ func addMetadataToCodelab(m map[string]string, c *types.Codelab) error {
 				return fmt.Errorf("invalid time metadata format: %v. Should be like 2017-04-21", err)
 			}
 			c.Published = types.ContextTime(t)
+			break
+		case metaImage:
+			// Directly assign the image link to the codelab field.
+			c.Image = v
 			break
 		default:
 			break

--- a/claat/types/meta.go
+++ b/claat/types/meta.go
@@ -37,6 +37,7 @@ type Meta struct {
 	GA         string        `json:"ga,omitempty"`         // Codelab-specific GA tracking ID
 	Difficulty int           `json:"difficulty,omitempty"` // Codelab-specific difficulty
 	Published  ContextTime   `json:"published,omitempty"`  // Last major publication timestamp
+	Image      string        `json:"image,omitempty"`      // Featured image link
 
 	URL string `json:"url"` // Legacy ID; TODO: remove
 }


### PR DESCRIPTION
This adds "image" metadata handling to allow for registering a featured image link as codelab metadata.